### PR TITLE
Break into two files to allow getting back a style object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,71 +1,13 @@
 'use strict'
 
-var array = require('cast-array')
+var getObject = require('./object')
 var toCss = require('to-css')
 var insertStyles = require('insert-styles')
-var elements = require('./elements.json')
 
 module.exports = function reset () {
-  var css = [
-    rule(elements, {
-      margin: 0,
-      padding: 0,
-      border: 0,
-      'font-size': '100%',
-      font: 'inherit',
-      'vertical-align': 'baseline'
-    }),
-    rule('body', {'line-height': 1}),
-    rule(['ol', 'ul'], {'list-style': 'none'}),
-    rule(['blockquote', 'q'], {quotes: 'none'}),
-    rule(['blockquote:before', 'blockquote:after', 'q:before', 'q:after'], {
-      content: ['', 'none']
-    }),
-    rule('table', {
-      'border-collapse': 'collapse',
-      'border-spacing': 0
-    }),
-    rule('button', {
-      background: 'none',
-      border: 'none',
-      outline: 'none',
-      'font-size': 'inherit',
-      margin: 0,
-      padding: 0,
-      font: 'inherit',
-      'line-height': 'normal'
-    }),
-    rule(['input:not([type=checkbox])', 'textarea'], {
-      background: 'none',
-      border: 'none',
-      outline: 'none',
-      font: 'inherit',
-      padding: 0,
-      margin: 0,
-      'border-radius': 0
-    }),
-    rule('input::-webkit-input-placeholder', {'line-height': 'normal'}),
-    rule('input:not([type=checkbox]):not([type=radio])', {'-webkit-appearance': 'none'}),
-    rule(['select:-moz-focusring', 'select::-moz-focus-inner'], {
-      color: 'transparent !important',
-      'text-shadow': '0 0 0 #000 !important'
-    }),
-    rule('body', {
-      '-webkit-tap-highlight-color': ['rgba(0,0,0,0)', 'transparent']
-    }),
-    rule('*', {'box-sizing': 'border-box'}),
-    rule('a', {'text-decoration': 'none'})
-  ]
-  .join('')
+  var css = toCss(getObject())
 
   insertStyles(css)
 
   return css
-}
-
-function rule (selectors, properties) {
-  var styles = {}
-  styles[array(selectors).join(', ')] = properties
-
-  return toCss(styles)
 }

--- a/object.js
+++ b/object.js
@@ -1,0 +1,69 @@
+'use strict'
+
+var array = require('cast-array')
+var assign = require('xtend/mutable')
+var elements = require('./elements.json')
+
+module.exports = function reset () {
+  var rules = [
+    rule(elements, {
+      margin: 0,
+      padding: 0,
+      border: 0,
+      'font-size': '100%',
+      font: 'inherit',
+      'vertical-align': 'baseline'
+    }),
+    rule('body', {'line-height': 1}),
+    rule(['ol', 'ul'], {'list-style': 'none'}),
+    rule(['blockquote', 'q'], {quotes: 'none'}),
+    rule(['blockquote:before', 'blockquote:after', 'q:before', 'q:after'], {
+      content: ['', 'none']
+    }),
+    rule('table', {
+      'border-collapse': 'collapse',
+      'border-spacing': 0
+    }),
+    rule('button', {
+      background: 'none',
+      border: 'none',
+      outline: 'none',
+      'font-size': 'inherit',
+      margin: 0,
+      padding: 0,
+      font: 'inherit',
+      'line-height': 'normal'
+    }),
+    rule(['input:not([type=checkbox])', 'textarea'], {
+      background: 'none',
+      border: 'none',
+      outline: 'none',
+      font: 'inherit',
+      padding: 0,
+      margin: 0,
+      'border-radius': 0
+    }),
+    rule('input::-webkit-input-placeholder', {'line-height': 'normal'}),
+    rule('input:not([type=checkbox]):not([type=radio])', {'-webkit-appearance': 'none'}),
+    rule(['select:-moz-focusring', 'select::-moz-focus-inner'], {
+      color: 'transparent !important',
+      'text-shadow': '0 0 0 #000 !important'
+    }),
+    rule('body', {
+      '-webkit-tap-highlight-color': ['rgba(0,0,0,0)', 'transparent']
+    }),
+    rule('*', {'box-sizing': 'border-box'}),
+    rule('a', {'text-decoration': 'none'})
+  ]
+
+  return rules.reduce(function (acc, rule) {
+    return assign(acc, rule)
+  }, {})
+}
+
+function rule (selectors, properties) {
+  var styles = {}
+  styles[array(selectors).join(', ')] = properties
+
+  return styles
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "files": [
     "index.js",
-    "elements.json"
+    "elements.json",
+    "object.js"
   ],
   "dependencies": {
     "cast-array": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "cast-array": "~1.0.1",
     "insert-styles": "~1.0.0",
-    "to-css": "~1.2.1"
+    "to-css": "~1.2.1",
+    "xtend": "^4.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,9 +2,16 @@
 
 var test = require('tape')
 var cssReset = require('./')
+var cssResetObject = require('./object')
 
-test(function (t) {
+test('string', function (t) {
   var css = cssReset()
   t.ok(css.indexOf('*{box-sizing:border-box;}') >= 0, 'combines reset rules')
+  t.end()
+})
+
+test('object', function (t) {
+  var rules = cssResetObject()
+  t.deepEqual(rules['*'], {'box-sizing': 'border-box'})
   t.end()
 })


### PR DESCRIPTION
Users can now `require('@eaze/css-reset/object')`